### PR TITLE
Fix jar name in plugin install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ cd java_plugin
 ./gradlew clean build          # downloads Gradle, compiles & tests
 
 # Copy plugin JAR into MagicDraw's plugins folder
-cp build/libs/compLete-plugin-1.0.0.jar \
+cp build/libs/compLete-1.0.0.jar \
    "/Applications/Cameo Systems Modeler/plugins/"
 ```
 


### PR DESCRIPTION
## Summary
- fix plugin install command to use `compLete-1.0.0.jar`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `./gradlew test --no-daemon` *(fails: No route to host while downloading dependencies)*