### PR TITLE
Clarify model validation feature in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 | Capability                          | Description                                                                                                                                 |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Model Validation**                | Automatically checks requirements coverage (e.g., ISO 26262, ASPICE) and flags unsatisfied requirements or missing elements.                |
+| **Model Validation**                | *Planned*: automatically check requirements coverage (e.g., ISO 26262, ASPICE) and flag unsatisfied requirements or missing elements. |
 | **Model Completion**                | AI-driven addition of missing Blocks, Ports, Connectors, and Requirement allocations from partial models and textual queries.               |
 | **Domain Grounding**                | Retrieval-Augmented Generation (RAG) using FAISS + SentenceTransformer over a curated corpus of standards, past models, and best practices. |
 | **Secure & Containerized**          | Token-based authentication, TLS on every API call, Docker/Docker-Compose for reproducible deployment.                                       |


### PR DESCRIPTION
## Summary
- clarify that `Model Validation` feature is planned but not yet implemented

## Testing
- `pytest -q` *(fails: command not found)*
- `./gradlew test --no-daemon` *(fails: no route to host)*