### PR TITLE
Fix Dockerfile path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ compLete/                     ← Git repo root
 │   │   ├── test_middleware.py
 │   │   └── test_rag.py
 │   ├── requirements.txt
-│   ├── Dockerfile
+│   ├── app/Dockerfile
 │   └── data/                         ← FAISS index & documents
 │
 └── java_plugin/              ← MagicDraw/Cameo plugin


### PR DESCRIPTION
## Summary
- point README layout section to `python_middleware/app/Dockerfile`

## Testing
- `pytest -q` *(fails: command not found)*
- `./gradlew test --quiet` *(fails to download Gradle due to no network)*