### PR TITLE
Extend middleware test

### DIFF
--- a/python_middleware/tests/test_middleware.py
+++ b/python_middleware/tests/test_middleware.py
@@ -17,3 +17,4 @@ def test_missing_body(client):
         '/complete_model', json={}, headers={'Authorization': 'Bearer testtoken'}
     )
     assert resp.status_code == 400
+    assert "error" in resp.get_json()


### PR DESCRIPTION
## Summary
- assert error message in middleware test

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*