### PR TITLE
Fix compose build path

### DIFF
--- a/python_middleware/docker-compose.yml
+++ b/python_middleware/docker-compose.yml
@@ -1,7 +1,9 @@
 version: '3.8'
 services:
   middleware:
-    build: .
+    build:
+      context: .
+      dockerfile: app/Dockerfile
     ports:
       - "5000:5000"
     environment:


### PR DESCRIPTION
## Summary
- configure python_middleware docker-compose to build using the Dockerfile in `app/`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_685350d139b08320a0f1006abd7d6636