### PR TITLE
Fix token import order in middleware tests

### DIFF
--- a/python_middleware/tests/test_middleware.py
+++ b/python_middleware/tests/test_middleware.py
@@ -1,10 +1,10 @@
 import os
+os.environ['FLASK_API_KEY'] = 'testtoken'
 import pytest
 from app.middleware import app
 
 @pytest.fixture
 def client():
-    os.environ['FLASK_API_KEY'] = 'testtoken'
     app.config['TESTING'] = True
     with app.test_client() as c:
         yield c


### PR DESCRIPTION
## Summary
- set `FLASK_API_KEY` before importing `app` in middleware tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_685350d208748320a81fb817d871a8ef