### PR TITLE
Fix session cleanup in SysMLModelService

### DIFF
--- a/java_plugin/src/main/java/com/complete/plugin/SysMLModelService.java
+++ b/java_plugin/src/main/java/com/complete/plugin/SysMLModelService.java
@@ -48,7 +48,8 @@ public class SysMLModelService {
     public void applySuggestions(String json) throws Exception {
         JSONObject s = new JSONObject(json);
         SessionManager.getInstance().createSession(project, "AI Completion");
-        Map<String, NamedElement> created = new HashMap<>();
+        try {
+            Map<String, NamedElement> created = new HashMap<>();
 
         // Blocks
         JSONArray newBlocks = s.optJSONArray("new_blocks");
@@ -86,7 +87,9 @@ public class SysMLModelService {
                 }
             }
         }
-
-        SessionManager.getInstance().closeSession(project);
+        }
+        finally {
+            SessionManager.getInstance().closeSession(project);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure sessions are always closed by using a `try`/`finally` block around `applySuggestions`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685350d388288320b8711bbd0d244831