### PR TITLE
Improve middleware error handling

### DIFF
--- a/java_plugin/src/main/java/com/complete/plugin/CompLetePlugin.java
+++ b/java_plugin/src/main/java/com/complete/plugin/CompLetePlugin.java
@@ -3,6 +3,7 @@ package com.complete.plugin;
 import com.nomagic.magicdraw.plugins.Plugin;
 import com.nomagic.magicdraw.plugins.PluginDescriptor;
 import javax.swing.*;
+import com.complete.plugin.HttpRequestException;
 
 public class CompLetePlugin extends Plugin {
     private SysMLModelService service;
@@ -21,10 +22,20 @@ public class CompLetePlugin extends Plugin {
             String ctx = service.extractModelContext();
             String json = service.requestCompletion(ctx, "Complete the model");
             service.applySuggestions(json);
+        } catch (HttpRequestException hre) {
+            JOptionPane.showMessageDialog(
+                null,
+                "Middleware error: " + hre.getMessage(),
+                "Error",
+                JOptionPane.ERROR_MESSAGE
+            );
         } catch (Exception ex) {
-            JOptionPane.showMessageDialog(null,
+            JOptionPane.showMessageDialog(
+                null,
                 "compLete error: " + ex.getMessage(),
-                "Error", JOptionPane.ERROR_MESSAGE);
+                "Error",
+                JOptionPane.ERROR_MESSAGE
+            );
         }
     }
 

--- a/java_plugin/src/main/java/com/complete/plugin/HttpClientHelper.java
+++ b/java_plugin/src/main/java/com/complete/plugin/HttpClientHelper.java
@@ -7,6 +7,7 @@ import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.json.JSONObject;
 import java.nio.charset.StandardCharsets;
+import com.complete.plugin.HttpRequestException;
 
 public class HttpClientHelper {
     private final CloseableHttpClient client;
@@ -28,8 +29,17 @@ public class HttpClientHelper {
         post.setHeader("Authorization", "Bearer " + apiKey);
         post.setHeader("Content-Type", "application/json");
         post.setEntity(new StringEntity(body.toString(), StandardCharsets.UTF_8));
-        return client.execute(post, resp ->
-            new String(resp.getEntity().getContent().readAllBytes(), StandardCharsets.UTF_8)
-        );
+
+        return client.execute(post, resp -> {
+            String respBody = new String(
+                resp.getEntity().getContent().readAllBytes(),
+                StandardCharsets.UTF_8
+            );
+            int code = resp.getCode();
+            if (code < 200 || code >= 300) {
+                throw new HttpRequestException(code, respBody);
+            }
+            return respBody;
+        });
     }
 }

--- a/java_plugin/src/main/java/com/complete/plugin/HttpRequestException.java
+++ b/java_plugin/src/main/java/com/complete/plugin/HttpRequestException.java
@@ -1,0 +1,20 @@
+package com.complete.plugin;
+
+public class HttpRequestException extends Exception {
+    private final int statusCode;
+    private final String responseBody;
+
+    public HttpRequestException(int statusCode, String responseBody) {
+        super("HTTP " + statusCode + ": " + responseBody);
+        this.statusCode = statusCode;
+        this.responseBody = responseBody;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getResponseBody() {
+        return responseBody;
+    }
+}

--- a/java_plugin/src/test/java/com/complete/plugin/HttpClientHelperTest.java
+++ b/java_plugin/src/test/java/com/complete/plugin/HttpClientHelperTest.java
@@ -1,0 +1,31 @@
+package com.complete.plugin;
+
+import com.sun.net.httpserver.HttpServer;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HttpClientHelperTest {
+    @Test
+    public void throwsExceptionOnNon2xx() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/fail", exchange -> {
+            byte[] body = "oops".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(500, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+        int port = server.getAddress().getPort();
+        HttpClientHelper client = new HttpClientHelper("http://localhost:" + port, "", 1000, 1000);
+        JSONObject obj = new JSONObject();
+        Exception ex = assertThrows(HttpRequestException.class, () -> client.post("/fail", obj));
+        assertTrue(ex.getMessage().contains("oops"));
+        server.stop(0);
+    }
+}


### PR DESCRIPTION
## Summary
- add HttpRequestException for 4xx/5xx HTTP errors
- throw HttpRequestException when middleware response code is not 2xx
- show middleware errors in CompLetePlugin
- test HttpClientHelper failure cases

## Testing
- `./java_plugin/gradlew -p java_plugin test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685350d3b1408320859538523105e57e