### PR TITLE
Update jar path default and clarify build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ cp build/libs/compLete-1.0.0.jar \
 
 Adjust `application.properties` inside the JAR (or re-package) to set the middleware URL and API key.
 
+The Python middleware's `execute_java_command` expects the built plugin JAR at
+`java_plugin/build/libs/compLete-1.0.0.jar`, so ensure the Gradle build step has
+been run before invoking that function.
+
 ---
 
 ### 3 · Use compLete inside MagicDraw

--- a/python_middleware/app/utils.py
+++ b/python_middleware/app/utils.py
@@ -2,7 +2,7 @@ import os
 import json
 import subprocess
 
-JAVA_JAR_PATH = os.getenv('JAVA_JAR_PATH', 'java_plugin/SysMLModelBuilder.jar')
+JAVA_JAR_PATH = os.getenv('JAVA_JAR_PATH', 'java_plugin/build/libs/compLete-1.0.0.jar')
 JAVA_CMD = os.getenv('JAVA_CMD', 'java')
 
 


### PR DESCRIPTION
## Summary
- use the Gradle-built plugin jar by default when invoking Java
- document that the plugin must be built before executing Java commands

## Testing
- `PYTHONPATH=python_middleware pytest python_middleware/tests -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `cd java_plugin && ./gradlew test --quiet` *(fails: unable to download Gradle wrapper due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685350d46ac8832081a0e11dffb4cf0e